### PR TITLE
Fixed relative links in collections

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,3 +38,7 @@ just_the_docs:
 plugins:
   - jekyll-seo-tag
   - jekyll-relative-links
+
+relative_links:
+  enabled: true
+  collections: true


### PR DESCRIPTION
Some links were not being processed correctly by benbalter/jekyll-relative-links

Collections were disabled by default.
Now they work

https://github.com/benbalter/jekyll-relative-links#processing-collections
