### PR TITLE
RFC: Quay.io

### DIFF
--- a/_published/0011-quay.io.md
+++ b/_published/0011-quay.io.md
@@ -12,9 +12,9 @@ rfc_author_username: jilleJr
 rfc_author_name: Kalle Jillheden # Or same as username, if you wish
 
 # Leave these. Collaborator changes this before merging
-impl_issue_id: 0
-impl_issue_repo: iver-wharf/wharf-api
-last_modified_date: YYYY-MM-DD
+impl_issue_id: 49
+impl_issue_repo: iver-wharf/iver-wharf.github.io
+last_modified_date: 2021-05-27
 ---
 
 # {{page.title}}

--- a/_published/0011-quay.io.md
+++ b/_published/0011-quay.io.md
@@ -1,0 +1,121 @@
+---
+layout: default
+# This is just to fool remark-stringify not to escape & symbols
+# See https://github.com/syntax-tree/mdast-util-to-markdown/issues/8
+shields_io_query_params: label=issue%20state&logo=github&style=flat-square
+
+# Update the following (it's YAML syntax)
+pr_id: 11 # Update this with PR number/ID. No leading zeros
+rfc_id: 0011 # Update this with PR number/ID. Use leading zeros
+rfc_feature_name: quay.io # Use kebab-case
+title: "RFC-0011: quay.io"
+rfc_author_username: jilleJr
+rfc_author_name: Kalle Jillheden # Or same as username, if you wish
+
+# Leave these. Collaborator changes this before merging
+impl_issue_id: 0
+impl_issue_repo: iver-wharf/wharf-api
+last_modified_date: YYYY-MM-DD
+---
+
+# {{page.title}}
+
+- RFC PR: [iver-wharf/rfcs#{{page.pr_id}}](https://github.com/iver-wharf/rfcs/pulls/{{page.pr_id}})
+- Feature name: `{{page.rfc_feature_name}}`
+- Author: {{page.rfc_author_name}} ([@{{page.rfc_author_username}}](https://github.com/{{page.rfc_author_username}}))
+- Implementation issue: [{{page.impl_issue_repo}}#{{page.impl_issue_id}}](https://github.com/{{page.impl_issue_repo}}/issues/{{page.impl_issue_id}})
+- Implementation status: ![GitHub issue state](https://img.shields.io/github/issues/detail/state/{{page.impl_issue_repo}}/{{page.impl_issue_id}}?{{page.shields_io_query_params}})
+
+## Summary
+
+Hosting our built Docker images of our main API, web frontend, and provider
+APIs over at <https://quay.io/> by Red Hat.
+
+## Motivation
+
+We can no longer host our Docker images over at an internal Harbor as we have
+been doing up until now as we want to make the built images public for easier
+access and updating.
+
+Choosing quay.io is mainly for their analysing toolchain that you get for
+hosting your images there.
+
+## Explanation
+
+Run the Wharf web locally by doing:
+
+```sh
+docker run --rm -it quay.io/iver-wharf/wharf-web
+```
+
+All our built Docker images can be found over at:
+
+- `docker pull quay.io/iver-wharf/wharf-web`
+  (<https://quay.io/repositories/iver-wharf/wharf-web>)
+
+- `docker pull quay.io/iver-wharf/wharf-api`
+  (<https://quay.io/repositories/iver-wharf/wharf-api>)
+
+- `docker pull quay.io/iver-wharf/wharf-provider-github`
+  (<https://quay.io/repositories/iver-wharf/wharf-provider-github>)
+
+- `docker pull quay.io/iver-wharf/wharf-provider-gitlab`
+  (<https://quay.io/repositories/iver-wharf/wharf-provider-gitlab>)
+
+- `docker pull quay.io/iver-wharf/wharf-provider-azuredevops`
+  (<https://quay.io/repositories/iver-wharf/wharf-provider-azuredevops>)
+
+To run a full instance of Wharf and its providers using Docker Compose, pull
+the repository <https://github.com/iver-wharf/wharf-docker-compose> and run:
+
+```sh
+docker-compose pull
+
+# The --abort-on-container-exit is a good flag to pass
+# It shuts down the entire suite if one of the containers errors out
+docker-compose up --abort-on-container-exit
+```
+
+To run one of the Wharf components from local source code then follow the
+["Getting started with development of Wharf"](https://iver-wharf.github.io/#/development/getting-started)
+guide to clone the repos you wish to edit and then link the
+`docker-compose.yml` file as instructed there. Then you can build the component
+you have modified and run the suite of containers like so:
+
+```sh
+# Builds the "api" service, which should be located in a folder named wharf-api
+# next to the docker-compose.yml file
+docker-compose build api
+
+# Now the main API service is based on your source code, while the other
+# components use our latest upstream prebuilt images.
+docker-compose up --abort-on-container-exit
+```
+
+## Compatibility
+
+Nothing comes to mind.
+
+## Alternative solutions
+
+Docker Hub (<https://hub.docker.com>) is more common, however with their lack
+of image security scanning in their free tier and the fact that Quay is an
+OSS project (<https://github.com/quay/quay>) this makes Quay.io the prominent
+choice.
+
+Quay also uses [Clair](https://github.com/quay/clair) for its security
+analysis. We are already using Clair in our internal [Harbor](https://goharbor.io)
+installations for code scanning, so we're already used to its behavior.
+
+We could host Quay or Harbor publicly ourselves, but it's more hassle than it's
+worth when we have solutions like Quay.io available. Maybe in the future we
+move to self-hosted public instances of Harbor/Quay and some Git forge like
+GitLab, Gitea, Gogs, etc. But for now: no.
+
+## Future possibilities
+
+Nothing comes to mind.
+
+## Unresolved questions
+
+Nothing comes to mind.

--- a/_published/0011-quay.io.md
+++ b/_published/0011-quay.io.md
@@ -6,9 +6,8 @@ shields_io_query_params: label=issue%20state&logo=github&style=flat-square
 
 # Update the following (it's YAML syntax)
 pr_id: 11 # Update this with PR number/ID. No leading zeros
-rfc_id: 0011 # Update this with PR number/ID. Use leading zeros
 rfc_feature_name: quay.io # Use kebab-case
-title: "RFC-0011: quay.io"
+title: "RFC-0011: quay.io" # Update this with PR number/ID and feature name. Use leading zeros
 rfc_author_username: jilleJr
 rfc_author_name: Kalle Jillheden # Or same as username, if you wish
 


### PR DESCRIPTION
Hosting our built Docker images of our main API, web frontend, and provider APIs over at <https://quay.io/> by Red Hat.

## Rendered

Link to the markdown file here on GitHub. Example:
https://github.com/iver-wharf/rfcs/blob/2e9fe0c/_published/0011-quay.io.md
