### PR TITLE
Removed rfc_id frontmatter field

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -6,9 +6,8 @@ shields_io_query_params: label=issue%20state&logo=github&style=flat-square
 
 # Update the following (it's YAML syntax)
 pr_id: 0 # Update this with PR number/ID. No leading zeros
-rfc_id: 0000 # Update this with PR number/ID. Use leading zeros
 rfc_feature_name: name-of-my-feature # Use kebab-case
-title: "RFC-0000: name-of-my-feature"
+title: "RFC-0000: name-of-my-feature" # Update this with PR number/ID and feature name. Use leading zeros
 rfc_author_username: yourUsername
 rfc_author_name: Firstname Lastname # Or same as username, if you wish
 

--- a/_published/0004-core-lib-repo.md
+++ b/_published/0004-core-lib-repo.md
@@ -6,9 +6,8 @@ shields_io_query_params: label=issue%20state&logo=github&style=flat-square
 
 # Update the following (it's YAML syntax)
 pr_id: 4 # Update this with PR number/ID. No leading zeros
-rfc_id: 0004 # Update this with PR number/ID. Use leading zeros
 rfc_feature_name: core-lib-repo # Use kebab-case
-title: "RFC-0004: core-lib-repo"
+title: "RFC-0004: core-lib-repo" # Update this with PR number/ID and feature name. Use leading zeros
 rfc_author_username: jilleJr
 rfc_author_name: Kalle Jillheden # Or same as username, if you wish
 

--- a/_published/0008-codacy.md
+++ b/_published/0008-codacy.md
@@ -6,9 +6,8 @@ shields_io_query_params: label=issue%20state&logo=github&style=flat-square
 
 # Update the following (it's YAML syntax)
 pr_id: 8 # Update this with PR number/ID. No leading zeros
-rfc_id: 0008 # Update this with PR number/ID. Use leading zeros
 rfc_feature_name: codacy # Use kebab-case
-title: "RFC-0008: codacy"
+title: "RFC-0008: codacy" # Update this with PR number/ID and feature name. Use leading zeros
 rfc_author_username: jilleJr
 rfc_author_name: Kalle Jillheden # Or same as username, if you wish
 


### PR DESCRIPTION
The `rfc_id` frontmatter field was unused, and as it was in YAML it was even parsed as an octal integer instead of a decimal integer. Noticed it in #11 where `rfc_id: 0011` got translated into `rfc_id = 9`...

