### PR TITLE
Added header styling

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,39 +1,39 @@
 :root {
-	color-scheme: dark;
+  color-scheme: dark;
 }
 
 h1::before {
-	color: #f5f6fa;
-	content: '# ';
-	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+  color: #f5f6fa;
+  content: '# ';
+  font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
 }
 
 h2 {
-	border-bottom: 1px solid #f5f6fa;
+  border-bottom: 1px solid #f5f6fa;
 }
 
 h2::before {
-	color: #f5f6fa;
-	content: '## ';
-	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+  color: #f5f6fa;
+  content: '## ';
+  font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
 }
 
 h3 {
-	border-bottom: 1px dotted #94959a;
+  border-bottom: 1px dotted #94959a;
 }
 
 h3::before {
-	color: #94959a;
-	content: '### ';
-	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+  color: #94959a;
+  content: '### ';
+  font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
 }
 
 h4 {
-	border-bottom: 1px dotted #5e5f63;
+  border-bottom: 1px dotted #5e5f63;
 }
 
 h4::before {
-	color: #5e5f63;
-	content: '#### ';
-	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+  color: #5e5f63;
+  content: '#### ';
+  font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
 }

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,39 @@
+:root {
+	color-scheme: dark;
+}
+
+h1::before {
+	color: #f5f6fa;
+	content: '# ';
+	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+}
+
+h2 {
+	border-bottom: 1px solid #f5f6fa;
+}
+
+h2::before {
+	color: #f5f6fa;
+	content: '## ';
+	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+}
+
+h3 {
+	border-bottom: 1px dotted #94959a;
+}
+
+h3::before {
+	color: #94959a;
+	content: '### ';
+	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+}
+
+h4 {
+	border-bottom: 1px dotted #5e5f63;
+}
+
+h4::before {
+	color: #5e5f63;
+	content: '#### ';
+	font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
+}


### PR DESCRIPTION
I found that in some pages when reading RFCs it was difficult to distinguish between the different header levels, as well as distinguishing between header and regular paragraph in some cases.

This adds a bottom border and some `###` before the headers to make them stand out more.

Also sneaked in a `color-scheme` setting to tell the web browser that it's already dark theme'd, as my browser wants to make it darker in some senses, such as inverting the white bottom border to a black border, which didn't fit at all.

## Preview

Before:

![Screenshot from 2021-09-15 18-47-33](https://user-images.githubusercontent.com/2477952/133475689-4857affb-7faf-4993-86a4-d66c6cbc1c80.png)

After:

![Screenshot from 2021-09-15 18-47-20](https://user-images.githubusercontent.com/2477952/133475685-3c9557bc-343b-421b-91f4-f71758c6a7d7.png)

This page is used in the above screenshots: https://iver-wharf.github.io/rfcs/published/0017-azuredevops-repos-and-not-projects