### PR TITLE
Added styling for blockquotes

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -37,3 +37,13 @@ h4::before {
   content: '#### ';
   font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
 }
+
+blockquote {
+  margin: 0.5em 0;
+  padding: 0.1em 2rem 0.1em 1.5em; // <ul> & <ol> use padding-left: 1.5em
+  padding-left: calc(1.5em - 4px);
+  background: #0004;
+  background: linear-gradient(90deg, #1c1b1f 0%, #27262b00 100%);
+  border-radius: 4px;
+  border-left: 4px solid #302d36;
+}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -42,7 +42,7 @@ blockquote {
   margin: 0.5em 0;
   padding: 0.1em 2rem 0.1em 1.5em; // <ul> & <ol> use padding-left: 1.5em
   padding-left: calc(1.5em - 4px);
-  background: #0004;
+  background: #1c1b1f;
   background: linear-gradient(90deg, #1c1b1f 0%, #27262b00 100%);
   border-radius: 4px;
   border-left: 4px solid #302d36;


### PR DESCRIPTION
The lack of styling for block quotes was annoying me. It was very unclear that it was a blockquote. This adds much more emphasis on the fact that there's a block quote there.

The weird mix of using `em` and `px` is because I wanted to use the same alignment and border radius settings as the other components such as the tables and code blocks.

The left border is there to distinguish from nested blockquotes.

## Preview

### Before

![Screenshot from 2021-12-14 13-14-34](https://user-images.githubusercontent.com/2477952/145996544-500d9dc5-0576-4758-96a3-00c90cbb5004.png)

### After

![Screenshot from 2021-12-14 13-14-16](https://user-images.githubusercontent.com/2477952/145996552-e4f1a6cb-c0bc-4f2e-9eb9-2ec6fda8610a.png)
