### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: deps serve \
 	lint lint-md \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md
 
 deps:
 	bundle install

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,19 @@
+.PHONY: deps serve \
+	lint lint-md \
+	lint-fix lint-md-fix
 
-install:
+deps:
 	bundle install
+	npm install
 
 serve:
 	bundle exec jekyll serve --livereload
 
+lint: lint-md
+lint-fix: lint-fix-md
+
+lint-md:
+	npx remark . .github
+
+lint-fix-md:
+	npx remark . .github -o

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ if you want.
 
 ## Linting markdown
 
-Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-md # only lint Markdown files

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ if you want.
    bundle install
 
    # Optionally, if you have GNU make
-   make install
+   make deps
    ```
 
 4. Start the site. This does not need administrator access.
@@ -76,13 +76,18 @@ if you want.
 Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
 
 ```sh
-npm install
+make lint
 
-npm run lint
+make lint-md # only lint Markdown files
+```
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-fix
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,8 +1,4 @@
 {
-  "scripts": {
-    "lint": "remark .",
-    "lint-fix": "remark . -o"
-  },
   "devDependencies": {
     "remark-cli": "^9.0.0",
     "remark-frontmatter": "^3.0.0",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
